### PR TITLE
Use nngraph for a speed increase.

### DIFF
--- a/torch/rnn.lua
+++ b/torch/rnn.lua
@@ -3,6 +3,11 @@ require('cutorch')
 require('nn')
 require('cunn')
 require('rnn')
+require('nngraph')
+
+-- Should produce a speed increase.
+nn.FastLSTM.usenngraph = true
+
 -- cutorch.setDevice(2)
 
 cmd = torch.CmdLine()


### PR DESCRIPTION
While discussing this benchmark on this `rnn` [issue](https://github.com/Element-Research/rnn/issues/182), it was pointed out that using nngraph should give a speed increase. 
