### PR TITLE
Element Research rnn benchmark ++

### DIFF
--- a/theano/rnn.py
+++ b/theano/rnn.py
@@ -231,7 +231,7 @@ hidden_size = opts.hidden_size
 seq_length = opts.seq_length
 batch_size = opts.batch_size
 
-
+start = time.time()
 # Data
 
 n_samples = 100000
@@ -259,10 +259,10 @@ cost = ((output - y) ** 2).mean()
 updates = [(p, p - theano.shared(np.float32(0.01)) * g) for p, g in zip(rnn.params, T.grad(cost, rnn.params))]
 
 print 'compiling...'
-start = time.time()
 f_test = theano.function(inputs=[index], outputs=output, givens={x: x_values[index:index + batch_size]})
 f_train = theano.function(inputs=[index], outputs=cost, updates=updates, givens={x: x_values[index:index + batch_size], y: y_values[index:index + batch_size]})
-print "Setup"
+f_train(1)
+print "Setup : compile + forward/backward x 1"
 print "--- %s seconds" % time.time() - start
 
 start = time.time()

--- a/theano/rnn.py
+++ b/theano/rnn.py
@@ -259,9 +259,11 @@ cost = ((output - y) ** 2).mean()
 updates = [(p, p - theano.shared(np.float32(0.01)) * g) for p, g in zip(rnn.params, T.grad(cost, rnn.params))]
 
 print 'compiling...'
+start = time.time()
 f_test = theano.function(inputs=[index], outputs=output, givens={x: x_values[index:index + batch_size]})
 f_train = theano.function(inputs=[index], outputs=cost, updates=updates, givens={x: x_values[index:index + batch_size], y: y_values[index:index + batch_size]})
-
+print "Setup"
+print "--- %s seconds" % time.time() - start
 
 start = time.time()
 for k, i in enumerate(xrange(0, n_samples, batch_size)):


### PR DESCRIPTION
Changes : 
- simple rnn is faster (uses JoinTable + one Linear)
- uses torch.Timer() instead of os.clock() (more precise)
- calls cutorch.synchronize before measuring time. (Don't remember how to do this for theano, but it should be done as well).
- measures setup time (torch and theano)

It would be nice if the benchmarks included the `setup` time as well. 
Please update the benchmarks.
